### PR TITLE
Fix error when knitting a RMarkdown report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readDepth
 Title: Find regions of genomic copy number loss and gain from short
         reads
-Version: 0.9.8.4
+Version: 0.9.8.5
 Author: Chris Miller
 Description: Uses the depth of short reads in windows across the genome to 
 	     identify regions of genomic copy-number gain and loss

--- a/R/rd.R
+++ b/R/rd.R
@@ -18,7 +18,6 @@ readDepth <- function(rdo){
     doBinning(rdo@params, rdo@binParams, rdo@entrypoints, rdo@readInfo, chr)
   }
   rdo@chrs = b
-  closeAllConnections()
   gc() #just in case
 
 

--- a/R/rd.functions.R
+++ b/R/rd.functions.R
@@ -142,8 +142,9 @@ chrName <- function(num){
 ##
 bedAnnotationLength <- function(e){
   if(file.exists(e)){
-    a=scan(gzfile(e),what=0,quiet=TRUE)
-    closeAllConnections()
+    f=gzfile(e)
+    a=scan(f,what=0,quiet=TRUE)
+    close(f)
     return(sum((a[seq(2,(length(a)),2)]-a[seq(1,(length(a)-1),2)]+1)))
   }
   return(0)

--- a/R/rd.gccorrect.R
+++ b/R/rd.gccorrect.R
@@ -15,7 +15,6 @@ rd.gcCorrect <- function(rdo, meth=FALSE, outlierPercentage=0.01){
     rdo@chrs[[i]] = cbind(rdo@chrs[[i]],gcBins[[i]])
   }
   
-  closeAllConnections()
   gc()
 
   #if bisulfite reads, consider methylation before correcting
@@ -308,7 +307,6 @@ loessCorrect <- function(rdo,outlierPercentage=0.01, gcCorrRes=0.001){
     doCorrection(rdo@chrs[[chr]], gcCorrRes, adjustments, chr)
   }
   
-  closeAllConnections() 
   return(adjBins)
 }
 

--- a/R/rd.object.R
+++ b/R/rd.object.R
@@ -19,7 +19,6 @@ setMethod("initialize", "rdObject",
             verifyFiles(.Object@entrypoints$chr)
             .Object@readInfo=getReadInfo()             
             .Object@binParams=binParams(.Object@params, .Object@entrypoints, .Object@readInfo)
-             closeAllConnections()
             return(.Object)
           })
 }
@@ -196,7 +195,6 @@ addMapability <-function(entrypoints){
       entrypoints[which(entrypoints$chr==tmp[i]),]$mapPerc = tmp[i+1]
     }
     write.table(entrypoints[,c("chr","mapPerc")],file=mapTotalFileName,sep="\t",quote=F,row.names=F,col.names=F)
-    closeAllConnections()	
   }
 
   tmp = scan(mapTotalFileName,what="",quiet=TRUE)
@@ -207,7 +205,6 @@ addMapability <-function(entrypoints){
     }
   }
   
-  closeAllConnections()
   entrypoints$mapPerc= as.numeric(entrypoints$mapPerc)
   return(entrypoints)
 }


### PR DESCRIPTION
Hi, thanks for your package. 

I had, however, a problem running it under KnitR. The following line caused an error.

```
rdo = readDepth(rdo)

isIncomplete(con) : invalid connection 
Error in isOpen(con) : invalid connection
```

(similar to http://stackoverflow.com/questions/11162824/how-do-i-use-the-ggmap-librarys-get-map-function-inside-of-knitr)

The attached patch fixes the problem by removing `closeAllConnections` which seems unnecessary and at one place closing the particular connection we open.

After running the analysis, `showConnections` lists only stdin/out/err as expected.

```
> showConnections(T)
  description class      mode text   isopen   can read can write
0 "stdin"     "terminal" "r"  "text" "opened" "yes"    "no"     
1 "stdout"    "terminal" "w"  "text" "opened" "no"     "yes"    
2 "stderr"    "terminal" "w"  "text" "opened" "no"     "yes"    
```

Cheers,
Nastia
